### PR TITLE
Exclude exception types from being logged

### DIFF
--- a/Monitoring.UnitTests/LogAttributeTests.cs
+++ b/Monitoring.UnitTests/LogAttributeTests.cs
@@ -109,6 +109,24 @@ namespace PubComp.Aspects.Monitoring.UnitTests
         }
 
         [TestMethod]
+        public void TestLogConstructorExceptions_ExceptionExcludedFromLog_Exeption()
+        {
+            bool didCatchException = false;
+
+            try
+            {
+                var target = new LoggedMockD(true);
+            }
+            catch (ApplicationException)
+            {
+                didCatchException = true;
+            }
+
+            Assert.AreEqual(0, logList.Logs.Count, "A log written - the exception should have been excluded");
+            Assert.IsTrue(didCatchException, "Exception was not rethrown");
+        }
+
+        [TestMethod]
         public void TestLogConstructorExceptions_Exception()
         {
             bool didCatchException = false;

--- a/Monitoring.UnitTests/LogMocks/LoggedMockD.cs
+++ b/Monitoring.UnitTests/LogMocks/LoggedMockD.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks
+{
+    public class LoggedMockD : ILoggedMock
+    {
+        [LogExceptions(typeof(ApplicationException))]
+        public LoggedMockD(bool doThrow = true)
+        {
+            if (doThrow)
+                throw new ApplicationException();
+        }
+
+        [Log]
+        public void ThrowSomething()
+        {
+            throw new ApplicationException("Something");
+        }
+
+        [Log]
+        public void Short()
+        {
+        }
+
+        [Log("MyLog")]
+        public void Other()
+        {
+        }
+    }
+}


### PR DESCRIPTION
This will allow users to exclude certain Exception types from being written to the log.