### PR TITLE
Add LogIgnoreAttribute to ignore properties on logging

### DIFF
--- a/Monitoring.UnitTests/LogAttributeTests.cs
+++ b/Monitoring.UnitTests/LogAttributeTests.cs
@@ -5,6 +5,7 @@ using NLog;
 using NLog.Targets;
 using PubComp.Aspects.Monitoring.UnitTests.LogMocks;
 using PubComp.Aspects.Monitoring.UnitTests.LogMocks.Mocks2;
+using PubComp.Aspects.Monitoring.UnitTests.Objects;
 
 namespace PubComp.Aspects.Monitoring.UnitTests
 {
@@ -76,7 +77,7 @@ namespace PubComp.Aspects.Monitoring.UnitTests
 
             try
             {
-                target.ThrowSomething();
+                target.ThrowSomething(null);
             }
             catch (ApplicationException)
             {
@@ -146,10 +147,15 @@ namespace PubComp.Aspects.Monitoring.UnitTests
         private void TestLogEntryException(ILoggedMock target)
         {
             bool caughtException = false;
+            var objWithIgnoredProp = new LoggableObject()
+            {
+                ShouldBeIgnored = "ignored123",
+                ShouldBeLogged = "logged123"
+            };
 
             try
             {
-                target.ThrowSomething();
+                target.ThrowSomething(objWithIgnoredProp);
             }
             catch (ApplicationException)
             {
@@ -165,6 +171,9 @@ namespace PubComp.Aspects.Monitoring.UnitTests
             var expectedCallSite = $"{target.GetType().FullName}.{nameof(target.ThrowSomething)}";
             Assert.AreEqual(expectedCallSite, logList.Logs[0].GetCallSite());
             Assert.AreEqual(expectedCallSite, logList.Logs[1].GetCallSite());
+
+            Assert.IsTrue(logList.Logs[1].GetMessage().Contains(objWithIgnoredProp.ShouldBeLogged));
+            Assert.IsFalse(logList.Logs[1].GetMessage().Contains(objWithIgnoredProp.ShouldBeIgnored));
         }
 
         [TestMethod]
@@ -190,7 +199,7 @@ namespace PubComp.Aspects.Monitoring.UnitTests
 
             try
             {
-                await target.ThrowSomethingAsync();
+                await target.ThrowSomethingAsync(null);
             }
             catch (ApplicationException)
             {
@@ -255,10 +264,15 @@ namespace PubComp.Aspects.Monitoring.UnitTests
         private async Task TestLogEntryExceptionAsync(ILoggedAsyncMock target)
         {
             bool caughtException = false;
+            var objWithIgnoredProp = new LoggableObject()
+            {
+                ShouldBeIgnored = "ignored123",
+                ShouldBeLogged = "logged123"
+            };
 
             try
             {
-                await target.ThrowSomethingAsync();
+                await target.ThrowSomethingAsync(objWithIgnoredProp);
             }
             catch (ApplicationException)
             {
@@ -270,6 +284,9 @@ namespace PubComp.Aspects.Monitoring.UnitTests
             Assert.AreEqual(2, logList.Logs.Count);
             Assert.AreEqual(LogLevel.Trace, logList.Logs[0].GetLevel());
             Assert.AreEqual(LogLevel.Error, logList.Logs[1].GetLevel());
+
+            Assert.IsTrue(logList.Logs[1].GetMessage().Contains(objWithIgnoredProp.ShouldBeLogged));
+            Assert.IsFalse(logList.Logs[1].GetMessage().Contains(objWithIgnoredProp.ShouldBeIgnored));
         }
     }
 }

--- a/Monitoring.UnitTests/LogMocks/ILoggedAsyncMock.cs
+++ b/Monitoring.UnitTests/LogMocks/ILoggedAsyncMock.cs
@@ -1,10 +1,11 @@
 ﻿using System.Threading.Tasks;
+using PubComp.Aspects.Monitoring.UnitTests.Objects;
 
 namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks
 {
     public interface ILoggedAsyncMock
     {
-        Task ThrowSomethingAsync();
+        Task ThrowSomethingAsync(LoggableObject obj);
 
         Task ShortAsync();
     }

--- a/Monitoring.UnitTests/LogMocks/ILoggedMock.cs
+++ b/Monitoring.UnitTests/LogMocks/ILoggedMock.cs
@@ -1,8 +1,10 @@
-﻿namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks
+﻿using PubComp.Aspects.Monitoring.UnitTests.Objects;
+
+namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks
 {
     public interface ILoggedMock
     {
-        void ThrowSomething();
+        void ThrowSomething(LoggableObject obj);
 
         void Short();
     }

--- a/Monitoring.UnitTests/LogMocks/LoggedAsyncMockA.cs
+++ b/Monitoring.UnitTests/LogMocks/LoggedAsyncMockA.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using PubComp.Aspects.Monitoring.UnitTests.Objects;
 
 namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks
 {
@@ -13,7 +14,7 @@ namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks
         }
 
         [Log]
-        public async Task ThrowSomethingAsync()
+        public async Task ThrowSomethingAsync(LoggableObject obj)
         {
             await Task.Delay(10);
             throw new ApplicationException("Something");

--- a/Monitoring.UnitTests/LogMocks/LoggedAsyncMockB.cs
+++ b/Monitoring.UnitTests/LogMocks/LoggedAsyncMockB.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using PostSharp.Extensibility;
+using PubComp.Aspects.Monitoring.UnitTests.Objects;
 
 namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks
 {
@@ -14,7 +15,7 @@ namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks
             MulticastAttributes.Instance | MulticastAttributes.Public)]
     public class LoggedAsyncMockB : ILoggedAsyncMock
     {
-        public async Task ThrowSomethingAsync()
+        public async Task ThrowSomethingAsync(LoggableObject obj)
         {
             await Task.Delay(10);
             throw new ApplicationException("Something");

--- a/Monitoring.UnitTests/LogMocks/LoggedMockA.cs
+++ b/Monitoring.UnitTests/LogMocks/LoggedMockA.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using PubComp.Aspects.Monitoring.UnitTests.Objects;
 
 namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks
 {
@@ -12,7 +13,7 @@ namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks
         }
 
         [Log]
-        public void ThrowSomething()
+        public void ThrowSomething(LoggableObject obj)
         {
             throw new ApplicationException("Something");
         }

--- a/Monitoring.UnitTests/LogMocks/LoggedMockB.cs
+++ b/Monitoring.UnitTests/LogMocks/LoggedMockB.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using PostSharp.Extensibility;
+using PubComp.Aspects.Monitoring.UnitTests.Objects;
 
 namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks
 {
@@ -13,7 +14,7 @@ namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks
             MulticastAttributes.Instance | MulticastAttributes.Public)]
     public class LoggedMockB : ILoggedMock
     {
-        public void ThrowSomething()
+        public void ThrowSomething(LoggableObject obj)
         {
             throw new ApplicationException("Something");
         }

--- a/Monitoring.UnitTests/LogMocks/Mocks2/LoggedAsyncMockC.cs
+++ b/Monitoring.UnitTests/LogMocks/Mocks2/LoggedAsyncMockC.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Threading.Tasks;
+using PubComp.Aspects.Monitoring.UnitTests.Objects;
 
 namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks.Mocks2
 {
     public class LoggedAsyncMockC : ILoggedAsyncMock
     {
-        public async Task ThrowSomethingAsync()
+        public async Task ThrowSomethingAsync(LoggableObject obj)
         {
             await Task.Delay(10);
             throw new ApplicationException("Something");

--- a/Monitoring.UnitTests/LogMocks/Mocks2/LoggedMockC.cs
+++ b/Monitoring.UnitTests/LogMocks/Mocks2/LoggedMockC.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using PubComp.Aspects.Monitoring.UnitTests.Objects;
 
 namespace PubComp.Aspects.Monitoring.UnitTests.LogMocks.Mocks2
 {
     public class LoggedMockC : ILoggedMock
     {
-        public void ThrowSomething()
+        public void ThrowSomething(LoggableObject obj)
         {
             throw new ApplicationException("Something");
         }

--- a/Monitoring.UnitTests/Monitoring.UnitTests.csproj
+++ b/Monitoring.UnitTests/Monitoring.UnitTests.csproj
@@ -5,10 +5,10 @@
     <RootNamespace>PubComp.Aspects.Monitoring.UnitTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="NLog" Version="4.5.10" />
-    <PackageReference Include="PostSharp" Version="6.0.28" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="NLog" Version="4.7.9" />
+    <PackageReference Include="PostSharp" Version="6.9.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Monitoring\Monitoring.csproj" />

--- a/Monitoring.UnitTests/Monitoring.UnitTests.csproj
+++ b/Monitoring.UnitTests/Monitoring.UnitTests.csproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="NLog" Version="4.7.9" />
-    <PackageReference Include="PostSharp" Version="6.9.3" />
+    <PackageReference Include="NLog" Version="4.5.10" />
+    <PackageReference Include="PostSharp" Version="6.0.28" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Monitoring\Monitoring.csproj" />

--- a/Monitoring.UnitTests/Objects/LoggableObject.cs
+++ b/Monitoring.UnitTests/Objects/LoggableObject.cs
@@ -1,0 +1,10 @@
+﻿namespace PubComp.Aspects.Monitoring.UnitTests.Objects
+{
+    public class LoggableObject
+    {
+        [LogIgnore]
+        public string ShouldBeIgnored { get; set; }
+
+        public string ShouldBeLogged { get; set; }
+    }
+}

--- a/Monitoring/LogAttribute.cs
+++ b/Monitoring/LogAttribute.cs
@@ -27,6 +27,7 @@ namespace PubComp.Aspects.Monitoring
         private string exitMessage;
         private readonly LogLevelValue exceptionLogLevel;
         private readonly LogLevelValue enterExistLogLevel;
+        private static readonly JsonSerializerSettings LogSerializerSettings = new JsonSerializerSettings { ContractResolver = new LoggableContractResolver() };
 
         /// <summary>
         /// Creates a new LogAttribute
@@ -104,7 +105,7 @@ namespace PubComp.Aspects.Monitoring
             string enter, exit;
             if (this.doLogValuesOnEnterExit)
             {
-                var values = JsonConvert.SerializeObject(args.Arguments.ToArray());
+                var values = JsonConvert.SerializeObject(args.Arguments.ToArray(), LogSerializerSettings);
                 enter = string.Concat(this.enterMessage, ", values: ", values);
                 exit = string.Concat(this.exitMessage, ", values: ", values);
             }
@@ -126,7 +127,7 @@ namespace PubComp.Aspects.Monitoring
             {
                 string message = doLogValuesOnException
                     ? string.Concat("Exception in method: ", this.fullMethodName, ", values: ",
-                            JsonConvert.SerializeObject(args.Arguments.ToArray()))
+                            JsonConvert.SerializeObject(args.Arguments.ToArray(), LogSerializerSettings))
                     : string.Concat("Exception in method: ", this.fullMethodName);
 
                 this.logException(message, ex);
@@ -152,7 +153,7 @@ namespace PubComp.Aspects.Monitoring
             string enter, exit;
             if (this.doLogValuesOnEnterExit)
             {
-                var values = JsonConvert.SerializeObject(args.Arguments.ToArray());
+                var values = JsonConvert.SerializeObject(args.Arguments.ToArray(), LogSerializerSettings);
                 enter = string.Concat(this.enterMessage, ", values: ", values);
                 exit = string.Concat(this.exitMessage, ", values: ", values);
             }
@@ -174,7 +175,7 @@ namespace PubComp.Aspects.Monitoring
             {
                 string message = doLogValuesOnException
                     ? string.Concat("Exception in method: ", this.fullMethodName, ", values: ",
-                        JsonConvert.SerializeObject(args.Arguments.ToArray()))
+                        JsonConvert.SerializeObject(args.Arguments.ToArray(), LogSerializerSettings))
                     : string.Concat("Exception in method: ", this.fullMethodName);
 
                 this.logException(message, ex);

--- a/Monitoring/LogExceptionsAttribute.cs
+++ b/Monitoring/LogExceptionsAttribute.cs
@@ -20,6 +20,7 @@ namespace PubComp.Aspects.Monitoring
         [NonSerialized]
         private Action<string, Exception> logException;
         private readonly LogLevelValue exceptionLogLevel;
+        private static readonly JsonSerializerSettings LogSerializerSettings = new JsonSerializerSettings { ContractResolver = new LoggableContractResolver() };
 
         /// <summary>
         /// Creates a new LogExceptionsAttribute
@@ -76,7 +77,7 @@ namespace PubComp.Aspects.Monitoring
             {
                 string message = doLogValuesOnException
                     ? string.Concat("Exception in method: ", this.fullMethodName, ", values: ",
-                            JsonConvert.SerializeObject(args.Arguments.ToArray()))
+                            JsonConvert.SerializeObject(args.Arguments.ToArray(), LogSerializerSettings))
                     : string.Concat("Exception in method: ", this.fullMethodName);
 
                 this.logException(message, args.Exception);

--- a/Monitoring/LogIgnoreAttribute.cs
+++ b/Monitoring/LogIgnoreAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace PubComp.Aspects.Monitoring
+{
+    /// <summary>
+    /// Prevents this field or property from being serialized to the logs.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class LogIgnoreAttribute : Attribute
+    {
+    }
+}

--- a/Monitoring/LoggableContractResolver.cs
+++ b/Monitoring/LoggableContractResolver.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace PubComp.Aspects.Monitoring
+{
+    internal class LoggableContractResolver : DefaultContractResolver
+    {
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+
+            var property = base.CreateProperty(member, memberSerialization);
+            var excludeFromLog = member.CustomAttributes.Any(cad => cad.AttributeType == typeof(LogIgnoreAttribute));
+
+            if (excludeFromLog)
+            {
+                property.ShouldSerialize = obj => false;
+            }
+            return property;
+        }
+    }
+}

--- a/Monitoring/MonitorAttribute.cs
+++ b/Monitoring/MonitorAttribute.cs
@@ -33,6 +33,7 @@ namespace PubComp.Aspects.Monitoring
         private string exitMessage;
         private readonly LogLevelValue exceptionLogLevel;
         private readonly LogLevelValue enterExistLogLevel;
+        private static readonly JsonSerializerSettings LogSerializerSettings = new JsonSerializerSettings { ContractResolver = new LoggableContractResolver() };
 
         #endregion
 
@@ -168,7 +169,7 @@ namespace PubComp.Aspects.Monitoring
             string enter, exit;
             if (this.doLogValuesOnEnterExit)
             {
-                var values = JsonConvert.SerializeObject(args.Arguments.ToArray());
+                var values = JsonConvert.SerializeObject(args.Arguments.ToArray(), LogSerializerSettings);
                 enter = string.Concat(this.enterMessage, ", values: ", values);
                 exit = string.Concat(this.exitMessage, ", values: ", values);
             }
@@ -200,7 +201,7 @@ namespace PubComp.Aspects.Monitoring
 
                 string message = doLogValuesOnException
                     ? string.Concat("Exception in method: ", this.fullMethodName, ", values: ",
-                            JsonConvert.SerializeObject(args.Arguments.ToArray()))
+                            JsonConvert.SerializeObject(args.Arguments.ToArray(), LogSerializerSettings))
                     : string.Concat("Exception in method: ", this.fullMethodName);
 
                 this.logException(message, ex);
@@ -250,7 +251,7 @@ namespace PubComp.Aspects.Monitoring
             string enter, exit;
             if (this.doLogValuesOnEnterExit)
             {
-                var values = JsonConvert.SerializeObject(args.Arguments.ToArray());
+                var values = JsonConvert.SerializeObject(args.Arguments.ToArray(), LogSerializerSettings);
                 enter = string.Concat(this.enterMessage, ", values: ", values);
                 exit = string.Concat(this.exitMessage, ", values: ", values);
             }
@@ -282,7 +283,7 @@ namespace PubComp.Aspects.Monitoring
 
                 string message = doLogValuesOnException
                     ? string.Concat("Exception in method: ", this.fullMethodName, ", values: ",
-                            JsonConvert.SerializeObject(args.Arguments.ToArray()))
+                            JsonConvert.SerializeObject(args.Arguments.ToArray(), LogSerializerSettings))
                     : string.Concat("Exception in method: ", this.fullMethodName);
 
                 this.logException(message, ex);

--- a/Monitoring/Monitoring.csproj
+++ b/Monitoring/Monitoring.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>PubComp.Aspects.Monitoring</AssemblyName>
     <RootNamespace>PubComp.Aspects.Monitoring</RootNamespace>

--- a/Monitoring/Monitoring.csproj
+++ b/Monitoring/Monitoring.csproj
@@ -9,9 +9,9 @@
     <FileVersion>3.3.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NLog" Version="4.7.9" />
-    <PackageReference Include="PostSharp" Version="6.9.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="NLog" Version="4.5.10" />
+    <PackageReference Include="PostSharp" Version="6.0.28" />
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="&quot;$(SolutionDir).NuGetPack\NuGetPack.exe&quot; &quot;$(ProjectPath)&quot; &quot;$(TargetPath)&quot; $(ConfigurationName)" />

--- a/Monitoring/Monitoring.csproj
+++ b/Monitoring/Monitoring.csproj
@@ -5,8 +5,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>PubComp.Aspects.Monitoring</AssemblyName>
     <RootNamespace>PubComp.Aspects.Monitoring</RootNamespace>
-    <AssemblyVersion>3.2.0.0</AssemblyVersion>
-    <FileVersion>3.2.0.0</FileVersion>
+    <AssemblyVersion>3.3.0.0</AssemblyVersion>
+    <FileVersion>3.3.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Monitoring/Monitoring.csproj
+++ b/Monitoring/Monitoring.csproj
@@ -9,9 +9,9 @@
     <FileVersion>3.2.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NLog" Version="4.5.10" />
-    <PackageReference Include="PostSharp" Version="6.0.28" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NLog" Version="4.7.9" />
+    <PackageReference Include="PostSharp" Version="6.9.3" />
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="&quot;$(SolutionDir).NuGetPack\NuGetPack.exe&quot; &quot;$(ProjectPath)&quot; &quot;$(TargetPath)&quot; $(ConfigurationName)" />

--- a/Monitoring/Monitoring.csproj
+++ b/Monitoring/Monitoring.csproj
@@ -5,7 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>PubComp.Aspects.Monitoring</AssemblyName>
     <RootNamespace>PubComp.Aspects.Monitoring</RootNamespace>
-    <AssemblyVersion>3.3.0.0</AssemblyVersion>
+    <AssemblyVersion>3.2.0.0</AssemblyVersion>
     <FileVersion>3.3.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This attribute will support teams which want to log entry/exit/exception values where some properties might include sensitive information. The Json serializer will not take any properties or fields decorated with the new `[LogIgnore]` attribute.